### PR TITLE
Update API base hostname

### DIFF
--- a/freshmail.py
+++ b/freshmail.py
@@ -17,7 +17,7 @@ class FreshMail(object):
     httpCode = ''
     contentType = 'application/json'
 
-    host = 'https://app.freshmail.pl/'
+    host = 'https://api.freshmail.com/'
     prefix = 'rest/'
 
 


### PR DESCRIPTION
New host name on http://freshmail.com/developer-api/description-of-api/
Official PHP library has been updated on 23 Febrary (FreshMail/REST-API@dc5581f0b02543d5ca7784b4281f5a04b48dc081)